### PR TITLE
Position of the Adopt Logo

### DIFF
--- a/src/components/layout.js
+++ b/src/components/layout.js
@@ -19,7 +19,7 @@ const Layout = ({ location, children }) => {
     );
   } else {
     header = (
-      <Link to={"/"} style={{ boxShadow: "none", color: "inherit" }}>
+      <Link to={"/"} style={{ boxShadow: "none", color: "inherit", lineHeight: "0px" }}>
         <img className="logo" alt="AdoptOpenJDK logo" src={withPrefix("adopt_logo_white.svg")} />
       </Link>
     );


### PR DESCRIPTION
The Adopt logo in the header has a different position on the "index" page and on a "post" page. On the "post" page the logo is wrapped in an `<a>` tag that is 8px higher than the logo and therefore the logo "jumps" some pixels to the top.

When changing the CSS of the rendered directly in Chrome adding the `line-height` property to the `<a>` tag works.

I can not start gatsby on my system and therefore I can not test my change. Next to this I have no idea about react 😁 