### PR TITLE
Fix typo in 'AdoptOpenJDK 11 Is the New Default'

### DIFF
--- a/content/blog/adoptopenjdk-11-new-default/index.md
+++ b/content/blog/adoptopenjdk-11-new-default/index.md
@@ -11,4 +11,4 @@ We have changed [the default version of AdoptOpenJDK that is offered for downloa
 
 It was about time: AdoptOpenJDK 11 was released almost two years ago on September 25th, 2018. This time gave the Java ecosystem and tooling vendors enough time to update. Even Android Studio and the Android SDK -- one of the last holdouts -- works with OpenJDK 11 out of the box. Other tools are even farther: IntelliJ IDEA requires OpenJDK 11 to run, and Visual Studio Code will soon only work with it, too. With the industry moving forward, we feel confident that AdoptOpenJDK 11 is from now on the best choice for our users.
 
-If you need help moving to AdoptOpenJDK, [All You Need To Know For Migrating To Java 11](https://blog.codefx.org/java/java-11-migration-guide/) by Nicolai Parlog brings you up to speed and provides a refresher about the new features.
+If you need help moving to AdoptOpenJDK 11, [All You Need To Know For Migrating To Java 11](https://blog.codefx.org/java/java-11-migration-guide/) by Nicolai Parlog brings you up to speed and provides a refresher about the new features.


### PR DESCRIPTION
Version number is missing in one place.