### PR TITLE
Enable CI on Windows, macOS

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -4,7 +4,12 @@ on:
     branches: [ master ]
 jobs:
   linter:
-    runs-on: ubuntu-latest
+    name: "Check on ${{ matrix.os }}"
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ ubuntu-latest, macos-latest, windows-latest ]
+
     steps:
     - name: Checkout
       uses: actions/checkout@v1


### PR DESCRIPTION
All platforms are being used by our contributors, so we should make sure that the blog works on each platform.